### PR TITLE
Fixes Apr2024

### DIFF
--- a/content-scripts/index.js
+++ b/content-scripts/index.js
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-if (!document.getElementById('netsuite-tool-box')) injectScript()
-=======
 if (((document.URL).indexOf('&xml=') === -1) && (!document.getElementById('netsuite-tool-box'))) injectScript()
->>>>>>> dc35c82 (Fixes for native NetSuite XML view, Shift-click on Field ID)
 
 function onMessage (request, sender, sendResponse) {
     try {

--- a/content-scripts/index.js
+++ b/content-scripts/index.js
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 if (!document.getElementById('netsuite-tool-box')) injectScript()
+=======
+if (((document.URL).indexOf('&xml=') === -1) && (!document.getElementById('netsuite-tool-box'))) injectScript()
+>>>>>>> dc35c82 (Fixes for native NetSuite XML view, Shift-click on Field ID)
 
 function onMessage (request, sender, sendResponse) {
     try {

--- a/content-scripts/page-javascript-context.js
+++ b/content-scripts/page-javascript-context.js
@@ -215,7 +215,8 @@
         setTimeout(() => {
             target.parentElement.removeChild(message)
         }, 1000)
-        document.querySelectorAll('[data-window-button="close"]').item(0).click()
+
+        document.querySelectorAll('[data-window-button="close"]').item(0).click()        
     }
 
     function extractIdFromField (target) {

--- a/content-scripts/page-javascript-context.js
+++ b/content-scripts/page-javascript-context.js
@@ -215,8 +215,12 @@
         setTimeout(() => {
             target.parentElement.removeChild(message)
         }, 1000)
+<<<<<<< HEAD
 
         document.querySelector('.x-tool-close').click()
+=======
+        document.querySelectorAll('[data-window-button="close"]').item(0).click()
+>>>>>>> dc35c82 (Fixes for native NetSuite XML view, Shift-click on Field ID)
     }
 
     function extractIdFromField (target) {

--- a/content-scripts/page-javascript-context.js
+++ b/content-scripts/page-javascript-context.js
@@ -215,12 +215,7 @@
         setTimeout(() => {
             target.parentElement.removeChild(message)
         }, 1000)
-<<<<<<< HEAD
-
-        document.querySelector('.x-tool-close').click()
-=======
         document.querySelectorAll('[data-window-button="close"]').item(0).click()
->>>>>>> dc35c82 (Fixes for native NetSuite XML view, Shift-click on Field ID)
     }
 
     function extractIdFromField (target) {


### PR DESCRIPTION
Two changes included:

* Fix native &xml=t view to work when the extension is active by only loading the script if the URL doesn't include that string.

* Fix for Shift-clicking a field to copy its ID to the clipboard; compatible with the latest NetSuite version now.
