### PR TITLE
exclude login page from injecting to prevent clash with bitwarden 

### DIFF
--- a/content-scripts/index.js
+++ b/content-scripts/index.js
@@ -1,4 +1,14 @@
-if (((document.URL).indexOf('&xml=') === -1) && (!document.getElementById('netsuite-tool-box'))) injectScript()
+const isXml = document.URL.includes('&xml=')
+
+// add explicit check for login page to avoid injecting script
+// and causing errors on login page (and clashes with Bitwarden password manager)
+
+const isLoginPage = window.location.pathname.startsWith('/app/login')
+
+// don't inject on the login page
+if (!isXml && !isLoginPage && !document.getElementById('netsuite-tool-box')) {
+  injectScript()
+}
 
 function onMessage (request, sender, sendResponse) {
     try {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "NetSuite Toolbox",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "applications": {
     "gecko": {
       "id": "netsuitetoolbox@viniciussimoes"


### PR DESCRIPTION
ctrl+shift+L was clashing with the bitwarden password manager keyboard shortcut for logging in. 

Added an exclusion to prevent the script being injected on the NetSuite login page. 